### PR TITLE
fix: handle dumping of table/array of tables (#10, #13, #14)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ license-files = ["LICENCE*"]
 
 [dependency-groups]
 dev = [
+    "basedpyright>=1.37.1",
     "isort>=6.0.1",
     "mypy>=1.18.1",
     "ruff>=0.13.0",

--- a/tests/test-array-of-tables.py
+++ b/tests/test-array-of-tables.py
@@ -1,0 +1,77 @@
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#     "pydantic",
+#     "tomlantic @ ${PROJECT_ROOT}/",
+#     "tomlkit",
+# ]
+# ///
+
+
+from pydantic import BaseModel
+from tomlkit import dumps, loads  # pyright: ignore[reportUnknownVariableType]
+
+import tomlantic
+
+
+class Item(BaseModel):
+    name: str
+    value: int
+    active: bool
+
+
+class ConfigWithArray(BaseModel):
+    title: str
+    items: list[Item] = []
+
+
+ARRAY_TEST_EXAMPLE = """
+title = "Test Array"
+
+[[items]]
+name = "first"
+value = 1
+active = true
+
+[[items]]
+name = "second"
+value = 2
+active = false
+"""
+
+
+def test():
+    """test array of tables (list[BaseModel])"""
+
+    toml = tomlantic.ModelBoundTOML(ConfigWithArray, loads(ARRAY_TEST_EXAMPLE))
+
+    # Test 1: initial dump should work
+    _ = dumps(toml.model_dump_toml())
+
+    # Test 2: modify existing item
+    toml.model.items[0].value = 10
+    dumped = dumps(toml.model_dump_toml())
+    assert "value = 10" in dumped
+    assert "value = 2" in dumped
+
+    # Test 3: add new item
+    toml.model.items.append(
+        Item(
+            name="third",
+            value=3,
+            active=True,
+        )
+    )
+    dumped = dumps(toml.model_dump_toml())
+    assert 'name = "third"' in dumped
+
+    # Test 4: remove item (test array rebuild)
+    toml.model.items.pop(0)
+    dumped = dumps(toml.model_dump_toml())
+    assert 'name = "first"' not in dumped
+    assert 'name = "second"' in dumped
+    assert 'name = "third"' in dumped
+
+
+if __name__ == "__main__":
+    test()

--- a/tests/test.py
+++ b/tests/test.py
@@ -27,7 +27,9 @@ def resolve_binaries() -> dict[str, list[str]]:
             getenv("name", default="").startswith("nix"),
             getenv("NIX_STORE", default=None) is not None,
             getenv("IN_NIX_SHELL", default=None) is not None,
-            str(which("python")).startswith(getenv("NIX_STORE", default="")),
+            str(which("python")).startswith(
+                getenv("NIX_STORE", default="zsxgdfchgvjhbj")
+            ),
         ]
     ):
         # not in nix, detect uv or die

--- a/uv.lock
+++ b/uv.lock
@@ -12,6 +12,18 @@ wheels = [
 ]
 
 [[package]]
+name = "basedpyright"
+version = "1.37.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodejs-wheel-binaries" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0c/b0/fbba81ea29eed1274e965cd0445f0d6020b467ff4d3393791e4d6ae02e64/basedpyright-1.37.1.tar.gz", hash = "sha256:1f47bc6f45cbcc5d6f8619d60aa42128e4b38942f5118dcd4bc20c3466c5e02f", size = 25235384, upload-time = "2026-01-08T14:42:46.447Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ad/d6/6b33bb49f08d761d7c958a1e3cecfb3ffbdcf4ba6bbed65b23ab47516b75/basedpyright-1.37.1-py3-none-any.whl", hash = "sha256:caf3adfe54f51623241712f8b4367adb51ef8a8c2288e3e1ec4118319661340d", size = 12297397, upload-time = "2026-01-08T14:42:50.306Z" },
+]
+
+[[package]]
 name = "isort"
 version = "6.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -78,6 +90,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "nodejs-wheel-binaries"
+version = "24.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/f1/73182280e2c05f49a7c2c8dbd46144efe3f74f03f798fb90da67b4a93bbf/nodejs_wheel_binaries-24.13.0.tar.gz", hash = "sha256:766aed076e900061b83d3e76ad48bfec32a035ef0d41bd09c55e832eb93ef7a4", size = 8056, upload-time = "2026-01-14T11:05:33.653Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/dc/4d7548aa74a5b446d093f03aff4fb236b570959d793f21c9c42ab6ad870a/nodejs_wheel_binaries-24.13.0-py2.py3-none-macosx_13_0_arm64.whl", hash = "sha256:356654baa37bfd894e447e7e00268db403ea1d223863963459a0fbcaaa1d9d48", size = 55133268, upload-time = "2026-01-14T11:05:05.335Z" },
+    { url = "https://files.pythonhosted.org/packages/24/8a/8a4454d28339487240dd2232f42f1090e4a58544c581792d427f6239798c/nodejs_wheel_binaries-24.13.0-py2.py3-none-macosx_13_0_x86_64.whl", hash = "sha256:92fdef7376120e575f8b397789bafcb13bbd22a1b4d21b060d200b14910f22a5", size = 55314800, upload-time = "2026-01-14T11:05:09.121Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/fb/46c600fcc748bd13bc536a735f11532a003b14f5c4dfd6865f5911672175/nodejs_wheel_binaries-24.13.0-py2.py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:3f619ac140e039ecd25f2f71d6e83ad1414017a24608531851b7c31dc140cdfd", size = 59666320, upload-time = "2026-01-14T11:05:12.369Z" },
+    { url = "https://files.pythonhosted.org/packages/85/47/d48f11fc5d1541ace5d806c62a45738a1db9ce33e85a06fe4cd3d9ce83f6/nodejs_wheel_binaries-24.13.0-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:dfb31ebc2c129538192ddb5bedd3d63d6de5d271437cd39ea26bf3fe229ba430", size = 60162447, upload-time = "2026-01-14T11:05:16.003Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/74/d285c579ae8157c925b577dde429543963b845e69cd006549e062d1cf5b6/nodejs_wheel_binaries-24.13.0-py2.py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:fdd720d7b378d5bb9b2710457bbc880d4c4d1270a94f13fbe257198ac707f358", size = 61659994, upload-time = "2026-01-14T11:05:19.68Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/97/88b4254a2ff93ed2eaed725f77b7d3d2d8d7973bf134359ce786db894faf/nodejs_wheel_binaries-24.13.0-py2.py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9ad6383613f3485a75b054647a09f1cd56d12380d7459184eebcf4a5d403f35c", size = 62244373, upload-time = "2026-01-14T11:05:23.987Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/c3/0e13a3da78f08cb58650971a6957ac7bfef84164b405176e53ab1e3584e2/nodejs_wheel_binaries-24.13.0-py2.py3-none-win_amd64.whl", hash = "sha256:605be4763e3ef427a3385a55da5a1bcf0a659aa2716eebbf23f332926d7e5f23", size = 41345528, upload-time = "2026-01-14T11:05:27.67Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/f1/0578d65b4e3dc572967fd702221ea1f42e1e60accfb6b0dd8d8f15410139/nodejs_wheel_binaries-24.13.0-py2.py3-none-win_arm64.whl", hash = "sha256:2e3431d869d6b2dbeef1d469ad0090babbdcc8baaa72c01dd3cc2c6121c96af5", size = 39054688, upload-time = "2026-01-14T11:05:30.739Z" },
 ]
 
 [[package]]
@@ -250,6 +278,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "basedpyright" },
     { name = "isort" },
     { name = "mypy" },
     { name = "ruff" },
@@ -264,6 +293,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "basedpyright", specifier = ">=1.37.1" },
     { name = "isort", specifier = ">=6.0.1" },
     { name = "mypy", specifier = ">=1.18.1" },
     { name = "ruff", specifier = ">=0.13.0" },


### PR DESCRIPTION
- Added helper functions: _is_dict_of_basemodels, _is_list_of_basemodels, _dicts_of_basemodels_differ, _lists_of_basemodels_differ
- Added _apply_basemodel_differences for recursive BaseModel processing
- Modified apply_model_differences to handle:
  - dict[str, BaseModel] (table of tables)
  - list[BaseModel] (array of tables)
- Added OutOfOrderTableProxy support for inline nested tables
- Added test file: tests/test-array-of-tables.py
- Updated dev dependencies to include basedpyright

---

- Resolves #10
- Resolves #13
- Resolves #14